### PR TITLE
Add users email as replyTo in feedback

### DIFF
--- a/src/lib/sendinblue.ts
+++ b/src/lib/sendinblue.ts
@@ -21,6 +21,7 @@ export interface SendEmailAttachment {
 }
 export interface SendTextParams {
   to: string
+  replyTo: string
   subject: string
   textContent: string
   attachment?: SendEmailAttachment[]
@@ -30,11 +31,13 @@ export const sendEmail = async ({
   subject,
   textContent,
   to,
+  replyTo,
   attachment,
 }: SendTextParams) => {
   const body = {
     sender,
     to: [{ email: to }],
+    replyTo: { email: replyTo },
     attachment: attachment && attachment.length > 0 ? attachment : undefined,
     subject,
     textContent,

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -28,6 +28,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     await sendEmail({
       to: 'navody@slovensko.digital',
+      replyTo: `${parsedBody.email || 'noreply@slovensko.digital'}`,
       subject: parsedBody.whatWereYouDoing,
       textContent: `${parsedBody.whatWentWrong}\n\n
 Email: ${parsedBody.email || '[neuvedený]'}


### PR DESCRIPTION
Napadlo nám takéto jednoduché vylepšienie feedbacku pre "administrátorov", že email, ktorý používateľ nepovinne vyplní do feedback formu, sa potom s feedbackom odošle v `replyTo` hlavičke, čiže admin potom vie odpovedať rovno tomu používateľovi.

Ak nedal svoj email, dáme tam nejaké noreply, aby admin videl, že nie je komu odpovedať.

Formát emailu sa kontroluje už na frontend. Preto to netreba komplikovať a stačí to rovno posielať.