### PR TITLE
INFRA add docker registry to gitlab config

### DIFF
--- a/.gitlab/auto-deploy-values.yaml
+++ b/.gitlab/auto-deploy-values.yaml
@@ -1,0 +1,4 @@
+image:
+  secrets:
+  - name: skdigital-bonet-registry
+


### PR DESCRIPTION
Toto nastavenie sa týka našej infraštruktúry. Priznanie je jednou z mnohých aplikácií, kde toto teraz pridávame.