### PR TITLE
Replace floor/ceil decimal with Round

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,4 @@
 import {
-  floorDecimal,
-  ceilDecimal,
   parseStreetAndNumber,
   encodeUnicodeCharacters,
   getStreetNumber,
@@ -318,50 +316,6 @@ describe('utils', () => {
     })
   })
 
-  describe('#floorDecimal', () => {
-    describe('for valid values', () => {
-      const validInputs = [
-        {
-          input: new Decimal(916.487),
-          output: new Decimal(916.48),
-        },
-        {
-          input: new Decimal(99.654),
-          output: new Decimal(99.65),
-        },
-      ]
-
-      validInputs.forEach(({ input, output }) => {
-        it(`should floor "${input}" to "${output}"`, () => {
-          expect(floorDecimal(input).equals(output)).toBeTruthy()
-        })
-      })
-    })
-  })
-  describe('#ceilDecimal', () => {
-    describe('for valid values', () => {
-      const validInputs = [
-        {
-          input: new Decimal(2864.094),
-          output: new Decimal(2864.1),
-        },
-        {
-          input: new Decimal(2864.444),
-          output: new Decimal(2864.45),
-        },
-        {
-          input: new Decimal(2864.099),
-          output: new Decimal(2864.1),
-        },
-      ]
-
-      validInputs.forEach(({ input, output }) => {
-        it(`should floor "${input}" to "${output}"`, () => {
-          expect(ceilDecimal(input).toNumber()).toEqual(output.toNumber())
-        })
-      })
-    })
-  })
   describe('#parseStreetAndNumber', () => {
     const scenarios = [
       { input: '  A. Bernoláka 6 ', output: ['A. Bernoláka', '6'] },

--- a/src/lib/calculation.ts
+++ b/src/lib/calculation.ts
@@ -2,10 +2,8 @@ import { ChildInput, TaxFormUserInput } from '../types/TaxFormUserInput'
 import { Child, TaxForm } from '../types/TaxForm'
 import {
   getRodneCisloAgeAtYearAndMonth,
-  floorDecimal,
   parseInputNumber,
   percentage,
-  ceilDecimal,
   sum,
   round,
 } from './utils'
@@ -231,7 +229,7 @@ export function calculate(input: TaxFormUserInput): TaxForm {
         return new Decimal(0)
       }
       if (this.r072_pred_znizenim.gt(MAX_ZAKLAD_DANE)) {
-        return ceilDecimal(
+        return round(
           Decimal.max(
             0,
             new Decimal(ZIVOTNE_MINIMUM_44_NASOBOK).minus(
@@ -303,7 +301,8 @@ export function calculate(input: TaxFormUserInput): TaxForm {
     //
     // ak je r. 40 viac ako je r. 77, potom na r. 78 uvediete rozdiel r. 40 - . 77
     get r078_zaklad_dane_zo_zamestnania() {
-      return floorDecimal(
+      // return floorDecimal(
+      return round(
         Decimal.max(this.r038.minus(this.r077_nezdanitelna_cast), 0),
       )
     },

--- a/src/lib/calculation.ts
+++ b/src/lib/calculation.ts
@@ -301,7 +301,6 @@ export function calculate(input: TaxFormUserInput): TaxForm {
     //
     // ak je r. 40 viac ako je r. 77, potom na r. 78 uvediete rozdiel r. 40 - . 77
     get r078_zaklad_dane_zo_zamestnania() {
-      // return floorDecimal(
       return round(
         Decimal.max(this.r038.minus(this.r077_nezdanitelna_cast), 0),
       )

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -162,19 +162,6 @@ export interface ParsedName {
   title: string
 }
 
-/**
- * @deprecated The method should not be used see issue https://github.com/slovensko-digital/priznanie-digital/issues/773
- */
-export const floorDecimal = (decimal: Decimal) => {
-  return decimal.toDecimalPlaces(2, Decimal.ROUND_FLOOR)
-}
-/**
- * @deprecated The method should not be used see issue https://github.com/slovensko-digital/priznanie-digital/issues/773
- */
-export const ceilDecimal = (decimal: Decimal) => {
-  return decimal.toDecimalPlaces(2, Decimal.ROUND_CEIL)
-}
-
 export const round = (decimal: Decimal): Decimal => {
   return decimal.toDecimalPlaces(2, Decimal.ROUND_HALF_UP)
 }


### PR DESCRIPTION
Fix #773 

Odstranil som `floor` aj `ceil` a nahradil ich `round`, ktory uz bol definovany podla [docs](https://mikemcl.github.io/decimal.js/#modes) a zahrna `ROUND_HALF_UP` co je presne to co potrebujeme.

Testy som rovnako odstranil a nove nepisal, kedze na `round` su testy uz tam a su v rozsahu aky potrebujeme.