### PR TITLE
don't fill in <r034a> xml element if not applicable

### DIFF
--- a/src/lib/calculation.ts
+++ b/src/lib/calculation.ts
@@ -152,7 +152,10 @@ export function calculate(input: TaxFormUserInput): TaxForm {
     },
 
     get r034a() {
-      return input.r034a
+      if (input.hasChildren && !input.prijmyPredJul22) {
+          return `${input.zaciatokPrijmovDen}.${input.zaciatokPrijmovMesiac}.${input.zaciatokPrijmovRok}`
+      }
+      return ''
     },
 
     /** SECTION Mortgage NAMES ARE WRONG TODO*/

--- a/src/pages/deti.tsx
+++ b/src/pages/deti.tsx
@@ -85,12 +85,6 @@ const Deti: Page<ChildrenUserInput> = ({
               ...childrenUserInputInitialValues,
               hasChildren: false,
             }
-          userInput = values.prijmyPredJul22
-            ? userInput
-            : {
-              ...userInput,
-              r034a: `${values.zaciatokPrijmovDen}.${values.zaciatokPrijmovMesiac}.${values.zaciatokPrijmovRok}`,
-            }
           setTaxFormUserInput(userInput)
           router.push(nextRoute)
         }}

--- a/src/types/PageUserInputs.ts
+++ b/src/types/PageUserInputs.ts
@@ -24,7 +24,6 @@ export type ChildrenUserInput = Pick<
   | 'hasChildren'
   | 'children'
   | 'prijmyPredJul22'
-  | 'r034a'
   | 'zaciatokPrijmovDen'
   | 'zaciatokPrijmovMesiac'
   | 'zaciatokPrijmovRok'


### PR DESCRIPTION
fixes #775

Possible situations are:
1. Asking for child bonus but income did not start on or after July 2022.
2. Asking for child bonus and income started on or after July 2022.
3. Not asking for child bonus.

For 1 the user input (prijmyPredJul22) is false and r034a is applicable. For 2 it is true and r034 is not applicable. For 3 there is no user input (prijmyPredJul22 is left undefined) but r034a is not applicable so let's treat this as if the input was true.