### PR TITLE
#972 Fix zalomenie sumy na vyplatenie

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -104,9 +104,9 @@ describe('utils', () => {
 
   describe('#formatCurrency', () => {
     const scenarios = [
-      { input: 1234.564, output: '1 234,56 EUR' },
+      { input: 1234.564, output: '1\u00A0234,56 EUR' },
       { input: 123.455, output: '123,46 EUR' },
-      { input: 1000000, output: '1 000 000,00 EUR' },
+      { input: 1000000, output: '1\u00A0000\u00A0000,00 EUR' },
     ]
 
     scenarios.forEach(({ input, output }) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,11 +6,9 @@ import { MAX_CHILD_AGE_BONUS, monthToKeyValue, TAX_YEAR } from './calculation'
 
 export const sortObjectKeys = (object: object) => {
   const ordered = {}
-  Object.keys(object)
-    .sort()
-    .forEach((key) => {
-      ordered[key] = object[key]
-    })
+  for (const key of Object.keys(object).sort()) {
+    ordered[key] = object[key]
+  }
   return ordered
 }
 
@@ -25,11 +23,7 @@ export const formatDate = (date: Date): string => {
 export const setDate = <T>(input: T, date: Date = null) => {
   if (date === null) {
     const now = new Date()
-    if (now.getFullYear() === TAX_YEAR) {
-      date = new Date(TAX_YEAR + 1, 0, 1)
-    } else {
-      date = now
-    }
+    date = now.getFullYear() === TAX_YEAR ? new Date(TAX_YEAR + 1, 0, 1) : now
   }
   return {
     ...input,
@@ -60,7 +54,7 @@ export const formatCurrency = (value: number): string => {
   const findPlaceForThousandsDivider = /\B(?=(\d{3})+(?!\d))/g
   const roundNumber = decimalToString(new Decimal(value || 0))
   const formattedNumber = roundNumber
-    .replace(findPlaceForThousandsDivider, ' ')
+    .replace(findPlaceForThousandsDivider, '\u00A0')
     .replace('.', ',')
   return `${formattedNumber} EUR`
 }
@@ -84,11 +78,9 @@ export const translit = (value: string) => {
 
 export const formatRodneCislo = (newValue: string, previousValue = '') => {
   const formattedNewValue = newValue.replace(/\D/g, '')
-  if (`${newValue} ` === previousValue) {
-    return newValue.slice(0, -3)
-  } else {
-    return formattedNewValue.replace(/^(\d{6})/, '$1 / ')
-  }
+  return `${newValue} ` === previousValue
+    ? newValue.slice(0, -3)
+    : formattedNewValue.replace(/^(\d{6})/, '$1 / ')
 }
 
 export const validateRodneCislo = (value: string): boolean => {
@@ -161,11 +153,9 @@ export const formatIban = (newValue: string, previousValue = '') => {
   const prefix = newValue.trim().slice(0, 2)
   const number = newValue.trim().slice(2).replace(/\D/g, '')
   const formattedNewValue = `${prefix}${number}`
-  if (`${newValue} ` === previousValue) {
-    return newValue.slice(0, -2)
-  } else {
-    return IBAN.printFormat(formattedNewValue)
-  }
+  return `${newValue} ` === previousValue
+    ? newValue.slice(0, -2)
+    : IBAN.printFormat(formattedNewValue)
 }
 
 export const validateIbanFormat = (value: string): boolean => {


### PR DESCRIPTION
- Replace the regular space character with a non-breaking space in `formatCurrency` function to prevent line breaks between numbers and currency symbols. Non-breaking spaces look the same as regular spaces but keep content together on the same line

- Update tests to account for this change

<img width="1210" alt="Screenshot 2025-04-20 at 21 54 47" src="https://github.com/user-attachments/assets/8562cc96-7948-4b02-b6fc-a782bf704e44" />
<img width="628" alt="Screenshot 2025-04-20 at 21 55 20" src="https://github.com/user-attachments/assets/543e62cd-ec22-4d19-bfc1-9e93d1797404" />
