### PR TITLE
chore: fix unused variables errors in test cases

### DIFF
--- a/cypress/e2e/executeCase.ts
+++ b/cypress/e2e/executeCase.ts
@@ -453,7 +453,7 @@ const executeTestCase = (testCase: string) => {
         /**  Validate our results with the FS form */
         cy.visit('/form/form.601.html')
         // Ignore uncaught exceptions in the 3rd party form code
-        cy.on('uncaught:exception', (err, runnable) => {
+        cy.on('uncaught:exception', (_err, _runnable) => {
           // returning false here prevents Cypress
           // inside the cy.origin() method from failing the test
           return false

--- a/cypress/e2e/pagePercent.spec.ts
+++ b/cypress/e2e/pagePercent.spec.ts
@@ -36,7 +36,7 @@ const getError = () => cy.get('[data-test=error]')
 beforeEach(() => {
   cy.setCookie('you-shall', 'not-pass') // allow direct access to pages via URL
   // Ignore uncaught exceptions in the 3rd party form code
-  cy.on('uncaught:exception', (err, runnable) => {
+  cy.on('uncaught:exception', (_err, _runnable) => {
     // returning false here prevents Cypress
     // inside the cy.origin() method from failing the test
     return false

--- a/cypress/e2e/random.spec.ts
+++ b/cypress/e2e/random.spec.ts
@@ -238,7 +238,7 @@ describe('Random inputs', () => {
           /**  Validate our results with the FS form */
           cy.visit('http://localhost:3000/form/form.601.html')
           // Ignore uncaught exceptions in the 3rd party form code
-          cy.on('uncaught:exception', (err, runnable) => {
+          cy.on('uncaught:exception', (_err, _runnable) => {
             // returning false here prevents Cypress
             // inside the cy.origin() method from failing the test
             return false


### PR DESCRIPTION
Toto je minor, len to na mna svietilo pri manipulovani s test caseami a fix je trivialny.

before:
<img width="1018" alt="Screenshot 2025-04-26 at 10 36 35" src="https://github.com/user-attachments/assets/8c46f471-21c2-4bcd-b3aa-0a4a1af7876f" />
after:
<img width="1018" alt="Screenshot 2025-04-26 at 10 36 42" src="https://github.com/user-attachments/assets/33621dc0-72a0-491a-a08b-aae6a734fa30" />
