### PR TITLE
Updates default branch reference in CI configuration

### DIFF
--- a/.github/workflows/form-check.yml
+++ b/.github/workflows/form-check.yml
@@ -91,7 +91,7 @@ jobs:
               repo: context.repo.repo,
               title: 'Update form files',
               head: `update-form-${process.env.hash}`,
-              base: 'master',  # Use 'main' if that's the default branch
+              base: 'master',
               body: 'This PR updates the form files to the latest version.'
             });
             console.log(`Pull Request created at ${pullRequest.html_url}`);


### PR DESCRIPTION
Adjusts the base branch reference from a comment to use 'master' explicitly for creating pull requests.

This change standardizes the branch used in automated workflows involving form updates.