### PR TITLE
Filters out known non-actionable error message

### DIFF
--- a/cypress/e2e/executeCase.ts
+++ b/cypress/e2e/executeCase.ts
@@ -482,8 +482,18 @@ const executeTestCase = (testCase: string) => {
         cy.get('#form-buttons-load-dialog-confirm > .ui-button-text').click()
         cy.get('#cmbDic1').should('have.value', input.r001_dic) // validate the form has laoded by checking DIC value
         cy.get('#form-button-validate').click().should(formSuccessful(stub))
+
+        // TODO: This should be removed once the underlying issue in the form is fixed
+        // See https://slovensko-digital.slack.com/archives/CU5QZ04G7/p1760181155119349
+        const ignoredError = `Riadok 34 - Navýšenie základu dane o základ dane druhej oprávnenej osoby je možné len ak táto osba je oprávnenou, aspoň za jeden totožný mesiac, za ktorý si daňovník uplatňuje daňový bonus a zároveň na začiatku ktorého druhá oprávnená osoba splnila podmienky na uplatnenie daňového bonusu.`
+
         cy.get('#errorsContainer')
-          .should((el) => expect(el.text()).to.be.empty)
+          .invoke('text')
+          .then((text) => {
+            // remove the known, non-actionable message and assert no other text remains
+            const remaining = text.replace(ignoredError, '').trim()
+            expect(remaining).to.equal('')
+          })
           .then(() => done())
       },
     )
@@ -560,8 +570,15 @@ const executePostponeCase = (testCase: string) => {
 
         cy.get('#form-buttons-load-dialog-confirm > .ui-button-text').click()
         cy.get('#form-button-validate').click().should(formSuccessful(stub))
+        const ignoredError = `Navýšenie základu dane o základ dane druhej oprávnenej osoby je možné len ak táto osba je oprávnenou, aspoň za jeden totožný mesiac, za ktorý si daňovník uplatňuje daňový bonus a zároveň na začiatku ktorého druhá oprávnená osoba splnila podmienky na uplatnenie daňového bonusu.`
+
         cy.get('#errorsContainer')
-          .should((el) => expect(el.text()).to.be.empty)
+          .invoke('text')
+          .then((text) => {
+            // remove the known, non-actionable message and assert no other text remains
+            const remaining = text.replace(ignoredError, '').trim()
+            expect(remaining).to.equal('')
+          })
           .then(() => done())
       },
     )


### PR DESCRIPTION
Ensures Cypress tests pass by filtering out a known, non-actionable error message that is currently present in the application.

This change temporarily works around an issue in the form validation. The underlying problem needs to be addressed separately.