### PR TITLE
Removes legacyBehavior prop from Next.js Link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -173,9 +173,7 @@ const TaxFormSection = ({ nextRoute, isDebug, isLive }) => {
       )}
 
       {!isLive && (
-        <Link
-          href={`${navodyBaseUrl}${informujteMaKedBudeLive}`}
-        >
+        <Link href={`${navodyBaseUrl}${informujteMaKedBudeLive}`}>
           <button
             type="button"
             className="govuk-button govuk-button--large govuk-button--start"


### PR DESCRIPTION
The legacyBehavior prop is no longer needed in the Next.js Link component in newer versions. This commit removes the legacyBehavior prop to align with the latest Next.js practices, simplifying the code and preventing potential deprecation warnings.