### PR TITLE
Updates wording for clarity and accuracy

### DIFF
--- a/src/pages/dve-percenta-rodicom.tsx
+++ b/src/pages/dve-percenta-rodicom.tsx
@@ -102,7 +102,7 @@ const DvePercentaRodicom: Page<DvePercentaRodicomUserInput> = ({
             <ErrorSummary<DvePercentaRodicomUserInput> errors={props.errors} />
             <Form className="form" noValidate>
               <Fieldset
-                title={`Chcete poukázať 2% dane rodičom?`}
+                title={`Chcete poukázať 2% dane rodičom, ktorí dovŕšili dôchodkový vek?`}
                 error={props.errors.dve_percenta_rodicom}
                 hint={`Môžete poukázať ${formatCurrency(calculatedTax.suma_2_percenta.toNumber())}, jednému alebo obidvom rodičom. Poukázanie 2% dane rodičom neovplyvňuje možnosť poukázať 2% alebo 3% dane neziskovej organizácii.`}
               >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -129,9 +129,6 @@ const TaxFormSection = ({ nextRoute, isDebug, isLive }) => {
               Príjem zo zahraničia (s výnimkou príjmov zo živnosti -
               poskytovanie služieb)
             </li>
-            <li>
-              Daňový bonus zo zvýšenia zaplatenej splátky úveru na bývanie
-            </li>
             <li>Daňové straty</li>
             <li>SZČO starobní dôchodcovia</li>
             <li>Záväzky a pohľadávky (tabuľka 1b)</li>


### PR DESCRIPTION
Clarifies the condition for claiming 2% tax for parents, specifying that they must be of retirement age.

Removes an outdated item from the tax form section to ensure accurate guidance.