### PR TITLE
Change getStreetNumber parameter from object to separate

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -95,7 +95,7 @@ describe('utils', () => {
 
     for (const { input, output } of scenarios) {
       it(`should format to ${output}`, () => {
-        expect(getStreetNumber(input)).toBe(output)
+        expect(getStreetNumber(input.reg_number, input.building_number)).toBe(output)
       })
     }
   })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,13 +31,10 @@ export const setDate = <T>(input: T, date: Date = null) => {
   }
 }
 
-export const getStreetNumber = ({
-  reg_number,
-  building_number,
-}: {
-  reg_number: number
-  building_number: string
-}): string => {
+export const getStreetNumber = (
+    reg_number: number,
+    building_number: string
+  ): string => {
   if (reg_number !== null && building_number !== null) {
     return `${reg_number}/${building_number}`
   }

--- a/src/pages/odklad/osobne-udaje.tsx
+++ b/src/pages/odklad/osobne-udaje.tsx
@@ -60,7 +60,7 @@ const makeHandlePersonAutoform = ({
       titul_za: postfixes || '',
       dic: `${subject.tin}` || '',
       ulica: street || municipality || '',
-      cislo: getStreetNumber({ reg_number, building_number }) || '',
+      cislo: getStreetNumber(reg_number, building_number) || '',
       psc: postal_code ? formatPsc(postal_code) : '',
       obec: municipality || '',
       stat: country === 'Slovenská republika' ? 'Slovensko' : '', // TODO: add mapping function for all possible countries from autoform to all options from form 548


### PR DESCRIPTION
Does this clean than object that same word appear twice?
```diff
diff --git a/src/lib/utils.ts b/src/lib/utils.ts
index 7c88fa9..fec8dd6 100644
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,13 +31,10 @@ export const setDate = <T>(input: T, date: Date = null) => {
   }
 }
 
-export const getStreetNumber = ({
-  reg_number,
-  building_number,
-}: {
-  reg_number: number
-  building_number: string
-}): string => {
+export const getStreetNumber = (
+    reg_number: number,
+    building_number: string
+  ): string => {
   if (reg_number !== null && building_number !== null) {
     return `${reg_number}/${building_number}`
   }

```