### PR TITLE
Adds assertions for r146 and r146a in JSON form

### DIFF
--- a/__tests__/danovyBonusNaDieta.test.ts
+++ b/__tests__/danovyBonusNaDieta.test.ts
@@ -1,4 +1,5 @@
 import { calculate } from '../src/lib/calculation'
+import { convertToJson } from '../src/lib/xml/xmlConverter'
 import { TaxFormUserInput } from '../src/types/TaxFormUserInput'
 import { initTaxFormUserInputValues } from '../src/lib/initialValues'
 
@@ -273,6 +274,12 @@ describe('Rows r146 and r146a – based on hasChildren value', () => {
     expect(result.r146.toNumber()).toBeGreaterThan(0)
     expect(result.r146a.toNumber()).toBeGreaterThan(0)
     expect(result.r146.toNumber()).toBe(result.r146a.toNumber())
+
+    const jsonForm = convertToJson(result)
+    expect(jsonForm.dokument.telo.r146).toBeDefined()
+    expect(jsonForm.dokument.telo.r146).not.toBe('')
+    expect(jsonForm.dokument.telo.r146a).toBeDefined()
+    expect(jsonForm.dokument.telo.r146a).not.toBe('')
   })
 
   test('r146 and r146a are filled when hasChildren is "income-used-by-someone-else"', () => {
@@ -287,6 +294,12 @@ describe('Rows r146 and r146a – based on hasChildren value', () => {
     expect(result.r146.toNumber()).toBeGreaterThan(0)
     expect(result.r146a.toNumber()).toBeGreaterThan(0)
     expect(result.r146.toNumber()).toBe(result.r146a.toNumber())
+
+    const jsonForm = convertToJson(result)
+    expect(jsonForm.dokument.telo.r146).toBeDefined()
+    expect(jsonForm.dokument.telo.r146).not.toBe('')
+    expect(jsonForm.dokument.telo.r146a).toBeDefined()
+    expect(jsonForm.dokument.telo.r146a).not.toBe('')
   })
 
   test('r146 and r146a are 0 when hasChildren is "no"', () => {
@@ -300,5 +313,9 @@ describe('Rows r146 and r146a – based on hasChildren value', () => {
 
     expect(result.r146.toNumber()).toBe(0)
     expect(result.r146a.toNumber()).toBe(0)
+
+    const jsonForm = convertToJson(result)
+    expect(jsonForm.dokument.telo.r146).toBe('')
+    expect(jsonForm.dokument.telo.r146a).toBe('')
   })
 })

--- a/src/lib/xml/xmlConverter.ts
+++ b/src/lib/xml/xmlConverter.ts
@@ -206,7 +206,7 @@ export function convertToJson(taxForm: TaxForm): OutputJson {
 
   form.dokument.telo.r135 = decimalToString(taxForm.r135_dan_na_uhradu)
   form.dokument.telo.r136 = decimalToString(taxForm.r136_danovy_preplatok)
-  if (taxForm.r146.greaterThan(0) && taxForm.r117.greaterThan(0)) {
+  if (taxForm.r146.greaterThan(0)) {
     form.dokument.telo.r146 = decimalToString(taxForm.r146)
     form.dokument.telo.r146a = decimalToString(taxForm.r146a)
   }


### PR DESCRIPTION
Adds assertions to check if the r146 and r146a rows are correctly converted to JSON format, including cases where the values are zero.

Removes unnecessary `r117` check in the xml conversion logic.